### PR TITLE
feat: add db_name variable to manage monitor notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.0.0]() (2025-06-26)
+
+### Features
+
+* Add Database Name filter for monitoring and alert for that Database only. That will support to separate the notifications each database in the same account to each channel we want.
+* Bump version to 1.0.0
 
 ## [0.2.0]() (2025-06-20)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The AWS account ID | `string` | n/a | yes |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Define database name to filter by datadog monitors | `string` | `""` | no |
 | <a name="input_enabled_modules"></a> [enabled\_modules](#input\_enabled\_modules) | List of modules to enable, must be one of billing, elasticache, rds | `list(string)` | `[]` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment monitored by this module | `string` | n/a | yes |
 | <a name="input_notification_slack_channel_prefix"></a> [notification\_slack\_channel\_prefix](#input\_notification\_slack\_channel\_prefix) | The prefix for Slack channels that will receive notifications and alerts | `string` | n/a | yes |

--- a/rds.tf
+++ b/rds.tf
@@ -20,7 +20,7 @@ locals {
       title_tags     = "[High CPU Utilization] [RDS]"
       title          = "RDS CPU Utilization is too high."
 
-      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}} by {dbinstanceidentifier} > $${threshold_critical}"
+      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -36,7 +36,7 @@ locals {
       title_tags     = "[High CPU Utilization] [RDS]"
       title          = "RDS CPU Utilization is high."
 
-      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}} by {dbinstanceidentifier} > $${threshold_critical}"
+      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -52,7 +52,7 @@ locals {
       title_tags     = "[High Storage Utilization] [RDS]"
       title          = "RDS Storage Utilization is too high."
 
-      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
+      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -69,7 +69,7 @@ locals {
       title_tags     = "[High Storage Utilization] [RDS]"
       title          = "RDS Storage Utilization is high."
 
-      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
+      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -86,7 +86,7 @@ locals {
       title_tags     = "[High P95 latency] [RDS]"
       title          = "RDS Query has a tremendous high P95 latency"
 
-      query_template = "percentile($${timeframe}):p95:trace.postgres.query{env:${var.environment}} by {resource_name} > $${threshold_critical}"
+      query_template = "percentile($${timeframe}):p95:trace.postgres.query{env:${var.environment}, dbinstanceidentifier:${var.db_name}} by {resource_name} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -102,7 +102,7 @@ locals {
       title_tags     = "[High Query Hits] [RDS]"
       title          = "RDS Query Hits is high"
 
-      query_template = "sum($${timeframe}):sum:trace.postgres.query.hits{env:${var.environment}}.as_count() > $${threshold_critical}"
+      query_template = "sum($${timeframe}):sum:trace.postgres.query.hits{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -118,7 +118,7 @@ locals {
       title_tags     = "[High Query Errors] [RDS]"
       title          = "RDS Query Errors is high"
 
-      query_template = "sum($${timeframe}):sum:trace.postgres.query.errors{env:${var.environment}}.as_count() > $${threshold_critical}"
+      query_template = "sum($${timeframe}):sum:trace.postgres.query.errors{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }

--- a/rds.tf
+++ b/rds.tf
@@ -18,9 +18,9 @@ locals {
     rds_cpu = {
       priority_level = 2
       title_tags     = "[High CPU Utilization] [RDS]"
-      title          = "RDS CPU Utilization is too high. - Database Name: ${var.db_name}"
+      title          = "RDS CPU Utilization is too high."
 
-      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
+      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name_regex}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -34,9 +34,9 @@ locals {
     rds_cpu_o1 = {
       priority_level = 3
       title_tags     = "[High CPU Utilization] [RDS]"
-      title          = "RDS CPU Utilization is high. - Database Name: ${var.db_name}"
+      title          = "RDS CPU Utilization is high."
 
-      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
+      query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name_regex}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -50,9 +50,9 @@ locals {
     rds_storage = {
       priority_level = 2
       title_tags     = "[High Storage Utilization] [RDS]"
-      title          = "RDS Storage Utilization is too high. - Database Name: ${var.db_name}"
+      title          = "RDS Storage Utilization is too high."
 
-      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
+      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name_regex}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -67,9 +67,9 @@ locals {
     rds_storage_o1 = {
       priority_level = 3
       title_tags     = "[High Storage Utilization] [RDS]"
-      title          = "RDS Storage Utilization is high. - Database Name: ${var.db_name}"
+      title          = "RDS Storage Utilization is high."
 
-      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
+      query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name_regex}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -84,9 +84,9 @@ locals {
     rds_query_p95 = {
       priority_level = 2
       title_tags     = "[High P95 latency] [RDS]"
-      title          = "RDS Query has a tremendous high P95 latency - Database Name: ${var.db_name}"
+      title          = "RDS Query has a tremendous high P95 latency"
 
-      query_template = "percentile($${timeframe}):p95:trace.postgres.query{env:${var.environment}, dbinstanceidentifier:${var.db_name}} by {resource_name} > $${threshold_critical}"
+      query_template = "percentile($${timeframe}):p95:trace.postgres.query{env:${var.environment}, dbinstanceidentifier:${var.db_name_regex}} by {resource_name} > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -100,9 +100,9 @@ locals {
     rds_query_hits = {
       priority_level = 5
       title_tags     = "[High Query Hits] [RDS]"
-      title          = "RDS Query Hits is high - Database Name: ${var.db_name}"
+      title          = "RDS Query Hits is high"
 
-      query_template = "sum($${timeframe}):sum:trace.postgres.query.hits{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
+      query_template = "sum($${timeframe}):sum:trace.postgres.query.hits{env:${var.environment}, dbinstanceidentifier:${var.db_name_regex}}.as_count() > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }
@@ -116,9 +116,9 @@ locals {
     rds_query_errors = {
       priority_level = 3
       title_tags     = "[High Query Errors] [RDS]"
-      title          = "RDS Query Errors is high - Database Name: ${var.db_name}"
+      title          = "RDS Query Errors is high"
 
-      query_template = "sum($${timeframe}):sum:trace.postgres.query.errors{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
+      query_template = "sum($${timeframe}):sum:trace.postgres.query.errors{env:${var.environment}, dbinstanceidentifier:${var.db_name_regex}}.as_count() > $${threshold_critical}"
       query_args = {
         timeframe = "last_5m"
       }

--- a/rds.tf
+++ b/rds.tf
@@ -18,7 +18,7 @@ locals {
     rds_cpu = {
       priority_level = 2
       title_tags     = "[High CPU Utilization] [RDS]"
-      title          = "RDS CPU Utilization is too high."
+      title          = "RDS CPU Utilization is too high. - Database Name: ${var.db_name}"
 
       query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
@@ -34,7 +34,7 @@ locals {
     rds_cpu_o1 = {
       priority_level = 3
       title_tags     = "[High CPU Utilization] [RDS]"
-      title          = "RDS CPU Utilization is high."
+      title          = "RDS CPU Utilization is high. - Database Name: ${var.db_name}"
 
       query_template = "avg($${timeframe}):avg:aws.rds.cpuutilization{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier} > $${threshold_critical}"
       query_args = {
@@ -50,7 +50,7 @@ locals {
     rds_storage = {
       priority_level = 2
       title_tags     = "[High Storage Utilization] [RDS]"
-      title          = "RDS Storage Utilization is too high."
+      title          = "RDS Storage Utilization is too high. - Database Name: ${var.db_name}"
 
       query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
@@ -67,7 +67,7 @@ locals {
     rds_storage_o1 = {
       priority_level = 3
       title_tags     = "[High Storage Utilization] [RDS]"
-      title          = "RDS Storage Utilization is high."
+      title          = "RDS Storage Utilization is high. - Database Name: ${var.db_name}"
 
       query_template = "avg($${timeframe}):100 - ((avg:aws.rds.free_storage_space{aws_account:${var.aws_account_id}, dbinstanceidentifier:${var.db_name}} by {dbinstanceidentifier,engine} / avg:aws.rds.total_storage_space{aws_account:${var.aws_account_id}} by {dbinstanceidentifier,engine}) * 100) > $${threshold_critical}"
       query_args = {
@@ -84,7 +84,7 @@ locals {
     rds_query_p95 = {
       priority_level = 2
       title_tags     = "[High P95 latency] [RDS]"
-      title          = "RDS Query has a tremendous high P95 latency"
+      title          = "RDS Query has a tremendous high P95 latency - Database Name: ${var.db_name}"
 
       query_template = "percentile($${timeframe}):p95:trace.postgres.query{env:${var.environment}, dbinstanceidentifier:${var.db_name}} by {resource_name} > $${threshold_critical}"
       query_args = {
@@ -100,7 +100,7 @@ locals {
     rds_query_hits = {
       priority_level = 5
       title_tags     = "[High Query Hits] [RDS]"
-      title          = "RDS Query Hits is high"
+      title          = "RDS Query Hits is high - Database Name: ${var.db_name}"
 
       query_template = "sum($${timeframe}):sum:trace.postgres.query.hits{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
       query_args = {
@@ -116,7 +116,7 @@ locals {
     rds_query_errors = {
       priority_level = 3
       title_tags     = "[High Query Errors] [RDS]"
-      title          = "RDS Query Errors is high"
+      title          = "RDS Query Errors is high - Database Name: ${var.db_name}"
 
       query_template = "sum($${timeframe}):sum:trace.postgres.query.errors{env:${var.environment}, dbinstanceidentifier:${var.db_name}}.as_count() > $${threshold_critical}"
       query_args = {

--- a/variables.tf
+++ b/variables.tf
@@ -8,19 +8,10 @@ variable "environment" {
   type        = string
 }
 
-variable "db_name" {
-  description = "Define database name to filter by datadog monitors"
+variable "db_name_regex" {
+  description = "Define database name to filter by datadog monitors, it will collects multiple datase in case it is `*`"
   type        = string
-  default     = ""
-
-  validation {
-    # This condition uses a ternary operator to check:
-    # IF 'rds' is in the enabled_modules list, THEN db_name must not be an empty string.
-    # ELSE (if 'rds' is not enabled), the condition is always true, so no validation is enforced.
-    condition     = contains(var.enabled_modules, "rds") ? var.db_name != "" : true
-    error_message = "The 'db_name' variable must be set when the 'rds' module is enabled."
-  }
-
+  default     = "*"
 }
 
 variable "notification_slack_channel_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,21 @@ variable "environment" {
   type        = string
 }
 
+variable "db_name" {
+  description = "Define database name to filter by datadog monitors"
+  type        = string
+  default     = ""
+
+  validation {
+    # This condition uses a ternary operator to check:
+    # IF 'rds' is in the enabled_modules list, THEN db_name must not be an empty string.
+    # ELSE (if 'rds' is not enabled), the condition is always true, so no validation is enforced.
+    condition     = contains(var.enabled_modules, "rds") ? var.db_name != "" : true
+    error_message = "The 'db_name' variable must be set when the 'rds' module is enabled."
+  }
+
+}
+
 variable "notification_slack_channel_prefix" {
   description = "The prefix for Slack channels that will receive notifications and alerts"
   type        = string


### PR DESCRIPTION
## Summary
## [1.0.0]() (2025-06-26)

### Features

* Add Database Name filter for monitoring and alert for that Database only. That will support to separate the notifications each database in the same account to each channel we want.
* Bump version to 1.0.0
<!--- Add some bells and whistles for PR template. --->

### Why
Currently, we cannot setup notification for each service to notify to each channel, especially in internal projects, using the same account id. We need to separate the query to get data from the specific db name only. For that configuration, we could create many modules to notify to desired channel.
<!--- Clearly define the issue or problem that your changes address. 
Describe what is currently not working as expected or what feature is missing. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
