### PR TITLE
feat: add MSK monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.2.0]() (2026-04-13)
+
+### Features
+
+* Add MSK (Amazon Managed Streaming for Apache Kafka) monitors: broker CPU, disk usage, offline partitions, active controller count
+
 ## [1.1.1]() (2025-12-08)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.46.0 |
 
 ## Providers
@@ -19,6 +20,7 @@ No providers.
 | <a name="module_elasticache"></a> [elasticache](#module\_elasticache) | c0x12c/monitors/datadog | ~> 1.0.0 |
 | <a name="module_emr"></a> [emr](#module\_emr) | c0x12c/monitors/datadog | ~> 1.0.0 |
 | <a name="module_kinesis"></a> [kinesis](#module\_kinesis) | c0x12c/monitors/datadog | ~> 1.0.0 |
+| <a name="module_msk"></a> [msk](#module\_msk) | c0x12c/monitors/datadog | ~> 1.0.0 |
 | <a name="module_rds"></a> [rds](#module\_rds) | c0x12c/monitors/datadog | ~> 1.0.0 |
 
 ## Resources

--- a/msk.tf
+++ b/msk.tf
@@ -1,0 +1,114 @@
+module "msk" {
+  source  = "c0x12c/monitors/datadog"
+  version = "~> 1.0.0"
+
+  notification_slack_channel_prefix = var.notification_slack_channel_prefix
+  tag_slack_channel                 = var.tag_slack_channel
+  environment                       = var.environment
+  service                           = "msk"
+
+  monitors = {
+    for monitor, config in local.default_msk_monitors :
+    monitor => merge(config, try(var.override_default_monitors[monitor], {})) if contains(var.enabled_modules, "msk")
+  }
+}
+
+locals {
+  default_msk_monitors = {
+    msk_cpu = {
+      priority_level = 2
+      title_tags     = "[High CPU Utilization] [MSK]"
+      title          = "MSK Broker CPU Utilization is too high."
+
+      query_template = "avg($${timeframe}):avg:aws.kafka.cpu_user{aws_account:${var.aws_account_id}} by {cluster_name,broker_id} > $${threshold_critical}"
+      query_args = {
+        timeframe = "last_10m"
+      }
+
+      threshold_critical          = 80
+      threshold_critical_recovery = 60
+      renotify_interval           = 30
+      renotify_occurrences        = 3
+    }
+
+    msk_cpu_o1 = {
+      priority_level = 3
+      title_tags     = "[High CPU Utilization] [MSK]"
+      title          = "MSK Broker CPU Utilization is high."
+
+      query_template = "avg($${timeframe}):avg:aws.kafka.cpu_user{aws_account:${var.aws_account_id}} by {cluster_name,broker_id} > $${threshold_critical}"
+      query_args = {
+        timeframe = "last_10m"
+      }
+
+      threshold_critical          = 60
+      threshold_critical_recovery = 40
+      renotify_interval           = 50
+      renotify_occurrences        = 3
+    }
+
+    msk_disk_used = {
+      priority_level = 2
+      title_tags     = "[High Disk Usage] [MSK]"
+      title          = "MSK Broker Disk Usage is too high."
+
+      query_template = "avg($${timeframe}):avg:aws.kafka.kafka_data_logs_disk_used{aws_account:${var.aws_account_id}} by {cluster_name,broker_id} > $${threshold_critical}"
+      query_args = {
+        timeframe = "last_10m"
+      }
+
+      threshold_critical          = 80
+      threshold_critical_recovery = 60
+      renotify_interval           = 30
+      renotify_occurrences        = 3
+    }
+
+    msk_disk_used_o1 = {
+      priority_level = 3
+      title_tags     = "[High Disk Usage] [MSK]"
+      title          = "MSK Broker Disk Usage is high."
+
+      query_template = "avg($${timeframe}):avg:aws.kafka.kafka_data_logs_disk_used{aws_account:${var.aws_account_id}} by {cluster_name,broker_id} > $${threshold_critical}"
+      query_args = {
+        timeframe = "last_10m"
+      }
+
+      threshold_critical          = 60
+      threshold_critical_recovery = 40
+      renotify_interval           = 50
+      renotify_occurrences        = 3
+    }
+
+    msk_offline_partitions = {
+      priority_level = 1
+      title_tags     = "[Offline Partitions] [MSK]"
+      title          = "MSK has offline partitions."
+
+      query_template = "avg($${timeframe}):sum:aws.kafka.offline_partitions_count{aws_account:${var.aws_account_id}} by {cluster_name} > $${threshold_critical}"
+      query_args = {
+        timeframe = "last_5m"
+      }
+
+      threshold_critical          = 0
+      threshold_critical_recovery = 0
+      renotify_interval           = 10
+      renotify_occurrences        = 5
+    }
+
+    msk_active_controller = {
+      priority_level = 2
+      title_tags     = "[Active Controller] [MSK]"
+      title          = "MSK Active Controller Count is abnormal."
+
+      query_template = "avg($${timeframe}):avg:aws.kafka.active_controller_count{aws_account:${var.aws_account_id}} by {cluster_name} < $${threshold_critical}"
+      query_args = {
+        timeframe = "last_5m"
+      }
+
+      threshold_critical          = 1
+      threshold_critical_recovery = 1
+      renotify_interval           = 10
+      renotify_occurrences        = 5
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "enabled_modules" {
   default     = []
 
   validation {
-    condition     = alltrue([for module_name in var.enabled_modules : contains(["billing", "elasticache", "rds", "airflow", "emr", "kinesis"], module_name)])
-    error_message = "Invalid module name, must be one of billing, elasticache, rds"
+    condition     = alltrue([for module_name in var.enabled_modules : contains(["billing", "elasticache", "msk", "rds", "airflow", "emr", "kinesis"], module_name)])
+    error_message = "Invalid module name, must be one of billing, elasticache, msk, rds, airflow, emr, kinesis"
   }
 }


### PR DESCRIPTION
## Summary
- Add MSK (Amazon Managed Streaming for Apache Kafka) monitor module with 6 monitors:
  - Broker CPU utilization (P2 > 80%, P3 > 60%)
  - Disk usage (P2 > 80%, P3 > 60%)
  - Offline partitions (P1 > 0)
  - Active controller count (P2 < 1)
- Add `"msk"` to `enabled_modules` validation
- Bump version to 1.2.0

## Test plan
- [ ] `terraform init -backend=false && terraform validate` passes
- [ ] Consumer repo (`8fleet-infra-terraform`) `terraform plan` succeeds with `enabled_modules = ["msk", "rds", "elasticache"]`
- [ ] Verify MSK monitors appear in Datadog after apply