### PR TITLE
fix: MSK active controller recovery threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.2.1]() (2026-04-13)
+
+### Fixes
+
+* Fix MSK active controller monitor: recovery threshold must be > alert threshold for `<` comparison
+
 ## [1.2.0]() (2026-04-13)
 
 ### Features

--- a/msk.tf
+++ b/msk.tf
@@ -106,7 +106,7 @@ locals {
       }
 
       threshold_critical          = 1
-      threshold_critical_recovery = 1
+      threshold_critical_recovery = 2
       renotify_interval           = 10
       renotify_occurrences        = 5
     }


### PR DESCRIPTION
## Summary
- Fix Datadog validation error: `recovery threshold (1.0) must be greater than the alert threshold (1.0) with < comparison`
- Change `threshold_critical_recovery` from `1` to `2` for `msk_active_controller` monitor

## Test plan
- [ ] `terraform plan` no longer fails on monitor validation