### PR TITLE
fix: bump to 1.2.2 with concise changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.2.2]() (2026-04-13)
+
+### Fixes
+
+- Fix MSK active controller monitor recovery threshold validation
+
 ## [1.2.1]() (2026-04-13)
 
 ### Fixes
 
-* Fix MSK active controller monitor: recovery threshold must be > alert threshold for `<` comparison
+- Fix MSK active controller monitor recovery threshold for less-than comparison
 
 ## [1.2.0]() (2026-04-13)
 


### PR DESCRIPTION
## Summary
- Bump version to 1.2.2 with simplified changelog entry to fix release workflow parsing error

## Test plan
- [ ] Release workflow creates v1.2.2 tag successfully