### PR TITLE
fix: MSK offline partitions threshold validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.2.3]() (2026-04-13)
+
+### Fixes
+
+- Fix MSK offline partitions monitor threshold validation
+
 ## [1.2.2]() (2026-04-13)
 
 ### Fixes

--- a/msk.tf
+++ b/msk.tf
@@ -89,7 +89,7 @@ locals {
         timeframe = "last_5m"
       }
 
-      threshold_critical          = 0
+      threshold_critical          = 1
       threshold_critical_recovery = 0
       renotify_interval           = 10
       renotify_occurrences        = 5


### PR DESCRIPTION
## Summary
- Fix offline partitions monitor: threshold_critical 0 with recovery 0 fails Datadog validation
- Changed to threshold_critical=1 (alert when any partition offline), recovery=0

## Test plan
- [ ] terraform plan succeeds with msk in enabled_modules